### PR TITLE
Added -f flag to rm, so the script doesn't complain.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -36,5 +36,5 @@ do
 	kill $RECORD_PID
 	adb pull /sdcard/screenrecord-data/$previous.m4v ./files || true &
 	adb shell rm /sdcard/screenrecord-data/$expired.m4v || true &
-	rm /sdcard/screenrecord-data/$expired3.m4v || true &
+	rm -f /sdcard/screenrecord-data/$expired3.m4v || true &
 done


### PR DESCRIPTION
Hey, sorry about tiny merge requests. I was going to add this to my previous pull request, but you merged it at lightning speed, so I didn't have time.

Btw, do you know what causes the "ERROR: unable to configure video/avc codec at 1200x1920 (err=-1010)" error? It keeps getting displayed in a loop.

I started making a small python script for streaming Android screen using similar method (I'm also adding remote control feature so you can control Android devices from computer), but I'm using screencap instead. The performance is extremely slow using both methods. Seems like adb can't handle a lot of data, so it makes video streaming slow, and when using screencap it's still slow, because with screencap there isn't any way of using lower resolution than phone screen size.
